### PR TITLE
Bug fix for Safari

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -38,7 +38,7 @@ export default {
   name: 'ni-countdown',
   computed: {
     usableDate () {
-      return Math.trunc(Date.parse(this.date) / 1000)
+      return Math.trunc(Date.parse(this.date.replace(/\s/, 'T')) / 1000)
     },
     seconds () {
       return (this.usableDate - this.now) % 60


### PR DESCRIPTION
Safari requires the date supplied to have a 'T' character rather than a space. Otherwise, the countdown shows NaN for each value. Problem is [described here](https://stackoverflow.com/questions/21883699/safari-javascript-date-nan-issue-yyyy-mm-dd-hhmmss#21884244
).